### PR TITLE
Feat: 클립 관리 도메인 기능 구현 완료 #71

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,7 @@ dependencies {
     implementation 'org.springframework.security:spring-security-oauth2-jose'
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-resource-server'
     implementation 'com.google.firebase:firebase-admin:8.1.0'
+    implementation 'org.springframework.boot:spring-boot-starter-hateoas'
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/noblesse/backend/clip/controller/ClipController.java
+++ b/src/main/java/com/noblesse/backend/clip/controller/ClipController.java
@@ -9,8 +9,11 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.io.IOException;
 
 @RestController
 @RequestMapping("/clip")
@@ -48,8 +51,16 @@ public class ClipController {
     @ApiResponse(responseCode = "200", content = @Content(mediaType = "application/json", schema = @Schema(implementation = Clip.class)))
     @PostMapping
     public ResponseEntity<?> registClip(@ModelAttribute ClipRegistRequestDTO clipRegistRequestDTO) {
-        clipService.insertClip(clipRegistRequestDTO);
-        return ResponseEntity.ok().build();
+        try {
+            clipService.insertClip(clipRegistRequestDTO);
+            return ResponseEntity.ok().build();
+        } catch (IOException e) {
+            // 로그 기록
+            System.err.println("클립 등록 중 오류 발생: " + e.getMessage());
+            // 클라이언트에게 오류 메시지 반환
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body("클립 등록 중 오류가 발생했습니다.");
+        }
     }
 
     @Operation(summary = "클립을 비공개/공개로 수정")

--- a/src/main/java/com/noblesse/backend/clip/controller/ClipReportController.java
+++ b/src/main/java/com/noblesse/backend/clip/controller/ClipReportController.java
@@ -14,6 +14,7 @@ import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/clipReport")
+@Tag(name = "클립 신고", description = "클립 신고 관련 API")
 public class ClipReportController {
     private final ClipReportService clipReportService;
 

--- a/src/main/java/com/noblesse/backend/clip/domain/Clip.java
+++ b/src/main/java/com/noblesse/backend/clip/domain/Clip.java
@@ -4,6 +4,8 @@ import jakarta.persistence.*;
 import org.hibernate.annotations.CreationTimestamp;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity(name = "Clip")
 @Table(name = "clip")
@@ -31,6 +33,9 @@ public class Clip {
 
     @Column(name = "TRIP_ID") // 해당 여행 TRIP_CODE
     private Long tripId;
+
+    @OneToMany(mappedBy = "clip", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ClipReport> reports = new ArrayList<>();
 
     protected Clip() {}
 

--- a/src/main/java/com/noblesse/backend/clip/domain/ClipReport.java
+++ b/src/main/java/com/noblesse/backend/clip/domain/ClipReport.java
@@ -23,23 +23,27 @@ public class ClipReport {
     private String clipReportContent;
 
     @CreationTimestamp
-    @Column(name = "CLIP_REPORT_DATETIME")
-    private LocalDateTime clipReportDateTime;
+    @Column(name = "CLIP_REPORTED_AT")
+    private LocalDateTime clipReportedAt; // 클립 정지 일자
 
     @Column(name = "USER_ID")
     private Long userId;
 
-    @Column(name = "CLIP_ID")
-    private Long clipId;
+//    @Column(name = "CLIP_ID")
+//    private Long clipId;
+
+    @ManyToOne
+    @JoinColumn(name = "CLIP_ID")
+    private Clip clip;
 
     protected ClipReport() {}
 
-    public ClipReport(Long reportCategoryId, String clipReportTitle, String clipReportContent, Long userId, Long clipId) {
+    public ClipReport(Long reportCategoryId, String clipReportTitle, String clipReportContent, Long userId, Clip clip) {
         this.reportCategoryId = reportCategoryId;
         this.clipReportTitle = clipReportTitle;
         this.clipReportContent = clipReportContent;
         this.userId = userId;
-        this.clipId = clipId;
+        this.clip = clip;
     }
 
     public void setReportCategoryId(Long reportCategoryId) {
@@ -54,12 +58,16 @@ public class ClipReport {
         this.clipReportContent = clipReportContent;
     }
 
-    public LocalDateTime getClipReportDateTime() {
-        return clipReportDateTime;
+    public LocalDateTime getClipReportedAt() {
+        return clipReportedAt;
     }
 
     public String getClipReportTitle() {
         return clipReportTitle;
+    }
+
+    public void setClipReportedAt(LocalDateTime clipReportedAt) {
+        this.clipReportedAt = clipReportedAt;
     }
 
     public Long getClipReportId() {
@@ -78,8 +86,16 @@ public class ClipReport {
         return userId;
     }
 
+    public void setUserId(Long userId) {
+        this.userId = userId;
+    }
+
     public Long getClipId() {
-        return clipId;
+        return clip != null ? clip.getClipId() : null;
+    }
+
+    public void setClip(Clip clip) {
+        this.clip = clip;
     }
 
     @Override
@@ -89,7 +105,8 @@ public class ClipReport {
                 ", reportCategoryId=" + reportCategoryId +
                 ", clipReportContent='" + clipReportContent + '\'' +
                 ", userId=" + userId +
-                ", clipId=" + clipId +
+                ", clipId=" + getClipId() +
+//                ", clipId=" + clipId +
                 '}';
     }
 }

--- a/src/main/java/com/noblesse/backend/clip/dto/ClipRegistRequestDTO.java
+++ b/src/main/java/com/noblesse/backend/clip/dto/ClipRegistRequestDTO.java
@@ -1,6 +1,7 @@
 package com.noblesse.backend.clip.dto;
 
 import lombok.*;
+import org.springframework.web.multipart.MultipartFile;
 
 @Getter
 @Setter
@@ -8,9 +9,11 @@ import lombok.*;
 @NoArgsConstructor
 @ToString
 public class ClipRegistRequestDTO {
+    private Long clipId;
     private String clipTitle;
     private String clipUrl;
     private Boolean isOpened;
     private Long userId;
     private Long tripId;
+    private MultipartFile file;
 }

--- a/src/main/java/com/noblesse/backend/clip/repository/ClipReportRepository.java
+++ b/src/main/java/com/noblesse/backend/clip/repository/ClipReportRepository.java
@@ -1,5 +1,6 @@
 package com.noblesse.backend.clip.repository;
 
+import com.noblesse.backend.clip.domain.Clip;
 import com.noblesse.backend.clip.domain.ClipReport;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -9,5 +10,7 @@ import java.util.List;
 @Repository
 public interface ClipReportRepository extends JpaRepository<ClipReport, Long> {
     ClipReport findClipReportByClipReportId(Long clipReportId);
-    List<ClipReport> findClipReportsByClipId(Long clipId);
+//    List<ClipReport> findClipReportsByClipId(Long clipId);
+    List<ClipReport> findClipReportsByClip_ClipId(Long clipId);
+    void deleteByClip(Clip clip);
 }

--- a/src/main/java/com/noblesse/backend/clip/service/ClipReportService.java
+++ b/src/main/java/com/noblesse/backend/clip/service/ClipReportService.java
@@ -1,8 +1,10 @@
 package com.noblesse.backend.clip.service;
 
+import com.noblesse.backend.clip.domain.Clip;
 import com.noblesse.backend.clip.domain.ClipReport;
 import com.noblesse.backend.clip.dto.ClipReportRegistRequestDTO;
 import com.noblesse.backend.clip.repository.ClipReportRepository;
+import com.noblesse.backend.clip.repository.ClipRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -11,9 +13,11 @@ import java.util.List;
 @Service
 public class ClipReportService {
     private final ClipReportRepository clipReportRepository;
+    private final ClipRepository clipRepository;
 
-    public ClipReportService(ClipReportRepository clipReportRepository) {
+    public ClipReportService(ClipReportRepository clipReportRepository, ClipRepository clipRepository) {
         this.clipReportRepository = clipReportRepository;
+        this.clipRepository = clipRepository;
     }
 
     public ClipReport findClipReportByClipReportId(Long clipReportId) {
@@ -21,21 +25,37 @@ public class ClipReportService {
     }
 
     public List<ClipReport> findClipReportsByClipId(Long clipId) {
-        return clipReportRepository.findClipReportsByClipId(clipId);
+//        return clipReportRepository.findClipReportsByClipId(clipId);
+        return clipReportRepository.findClipReportsByClip_ClipId(clipId);
     }
 
     public List<ClipReport> findAll() {
         return clipReportRepository.findAll();
     }
 
+    //    public void registClipReport(ClipReportRegistRequestDTO clipReportRegistRequestDTO) {
+//        clipReportRepository.save(new ClipReport(
+//                clipReportRegistRequestDTO.getReportCategoryId(),
+//                clipReportRegistRequestDTO.getClipReportTitle(),
+//                clipReportRegistRequestDTO.getClipReportContent(),
+//                clipReportRegistRequestDTO.getUserId(),
+//                clipReportRegistRequestDTO.getClipId()
+//        ));
+//    }
+    @Transactional
     public void registClipReport(ClipReportRegistRequestDTO clipReportRegistRequestDTO) {
-        clipReportRepository.save(new ClipReport(
+        Clip clip = clipRepository.findById(clipReportRegistRequestDTO.getClipId())
+                .orElseThrow(() -> new RuntimeException("Clip not found"));
+
+        ClipReport clipReport = new ClipReport(
                 clipReportRegistRequestDTO.getReportCategoryId(),
                 clipReportRegistRequestDTO.getClipReportTitle(),
                 clipReportRegistRequestDTO.getClipReportContent(),
                 clipReportRegistRequestDTO.getUserId(),
-                clipReportRegistRequestDTO.getClipId()
-        ));
+                clip
+        );
+
+        clipReportRepository.save(clipReport);
     }
 
     // UPDATE 문은 따로 필요 없을 듯, 신고 내용을 수정하는 정도에서는 제목, 내용 정도..?

--- a/src/main/java/com/noblesse/backend/clip/service/ClipService.java
+++ b/src/main/java/com/noblesse/backend/clip/service/ClipService.java
@@ -3,18 +3,22 @@ package com.noblesse.backend.clip.service;
 import com.noblesse.backend.clip.domain.Clip;
 import com.noblesse.backend.clip.dto.ClipRegistRequestDTO;
 import com.noblesse.backend.clip.repository.ClipRepository;
+import com.noblesse.backend.file.service.FileService;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.io.IOException;
 import java.util.List;
 
 @Service
 public class ClipService {
 
     private final ClipRepository clipRepository;
+    private final FileService fileService;
 
-    public ClipService(ClipRepository clipRepository) {
+    public ClipService(ClipRepository clipRepository, FileService fileService) {
         this.clipRepository = clipRepository;
+        this.fileService = fileService;
     }
 
     public Clip findClipByClipId(Long ClipId) {
@@ -25,15 +29,42 @@ public class ClipService {
         return clipRepository.findAll();
     }
 
+//    @Transactional
+//    public void insertClip(ClipRegistRequestDTO clipRegistRequestDTO) {
+//        clipRepository.save(new Clip(
+//                clipRegistRequestDTO.getClipTitle(),
+//                clipRegistRequestDTO.getClipUrl(),
+//                clipRegistRequestDTO.getIsOpened(),
+//                clipRegistRequestDTO.getUserId(),
+//                clipRegistRequestDTO.getTripId()
+//        ));
+//    }
+
     @Transactional
-    public void insertClip(ClipRegistRequestDTO clipRegistRequestDTO) {
-        clipRepository.save(new Clip(
-                clipRegistRequestDTO.getClipTitle(),
-                clipRegistRequestDTO.getClipUrl(),
-                clipRegistRequestDTO.getIsOpened(),
-                clipRegistRequestDTO.getUserId(),
-                clipRegistRequestDTO.getTripId()
-        ));
+    public void insertClip(ClipRegistRequestDTO clipRegistRequestDTO) throws IOException {
+        try {
+            Clip clip = new Clip(
+                    clipRegistRequestDTO.getClipTitle(),
+                    null, // 임시로 null 설정
+                    clipRegistRequestDTO.getIsOpened(),
+                    clipRegistRequestDTO.getUserId(),
+                    clipRegistRequestDTO.getTripId()
+            );
+
+            Clip savedClip = clipRepository.save(clip);
+
+            // 저장된 후에 clip_url 업데이트
+            String clipUrl = "clip/" + savedClip.getClipId() + "/" + clipRegistRequestDTO.getFile().getOriginalFilename();
+            savedClip.setClipUrl(clipUrl);
+            clipRepository.save(savedClip);
+
+            fileService.insertClipFile(clipRegistRequestDTO.getFile(), savedClip.getClipId(), savedClip.getClipTitle());
+        } catch (IOException e) {
+            // 로그 기록
+            System.err.println("클립 파일 저장 중 오류 발생: " + e.getMessage());
+            // 예외를 다시 던져서 상위 레벨에서 처리할 수 있게 함
+            throw new IOException("클립 파일 저장 중 오류가 발생했습니다.", e);
+        }
     }
 
     @Transactional
@@ -46,6 +77,7 @@ public class ClipService {
 
     @Transactional
     public void deleteClipByClipId(Long ClipId) {
+        fileService.deleteClipFileByClipId(ClipId);
         clipRepository.deleteById(ClipId);
     }
 }

--- a/src/main/java/com/noblesse/backend/file/service/FileService.java
+++ b/src/main/java/com/noblesse/backend/file/service/FileService.java
@@ -69,6 +69,27 @@ public class FileService {
     }
 
     @Transactional
+    public void insertClipFile(MultipartFile file, Long clipId, String clipTitle) throws IOException {
+        String fileName = file.getOriginalFilename();
+        String fileUrl = "clip/" + clipId + "/" + fileName;
+
+        imageFileService.uploadImageFile(file, "clip/" + clipId + "/");
+
+        fileRepository.save(new File(
+                "clip",
+                fileName,
+                fileUrl,
+                null,
+                null,
+                null,
+                clipId,
+                null
+        ));
+
+        System.out.println("클립 파일 추가 시간 : " + LocalDateTime.now());
+    }
+
+    @Transactional
     public String findImageDownloadLinkByPostIdAndFileName(Long postId, String fileName) {
         return imageFileService.findImageDownloadLink("post/" + postId + "/", fileName);
     }
@@ -130,5 +151,11 @@ public class FileService {
             imageFileService.deleteProfileImageByUserId(userId);
             fileRepository.deleteById(foundUser.getProfileId());
         }
+    }
+
+    @Transactional
+    public void deleteClipFileByClipId(Long clipId) {
+        imageFileService.deleteImagesByClipId(clipId);
+        fileRepository.deleteFilesByClipId(clipId);
     }
 }

--- a/src/main/java/com/noblesse/backend/global/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/noblesse/backend/global/handler/GlobalExceptionHandler.java
@@ -7,6 +7,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
 @Slf4j
 @ControllerAdvice
@@ -40,6 +41,19 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ErrorResponse> handleEntityNotFoundException(EntityNotFoundException ex) {
         log.error("# Handling EntityNotFoundException: ", ex);
         ErrorResponse error = new ErrorResponse("NOT_FOUND", ex.getMessage());
+
         return new ResponseEntity<>(error, HttpStatus.NOT_FOUND);
+    }
+
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    public ResponseEntity<ErrorResponse> handleMethodArgumentTypeMismatch(MethodArgumentTypeMismatchException ex) {
+        log.error("# Handling MethodArgumentTypeMismatchException: ", ex);
+        String name = ex.getName();
+        String type = ex.getRequiredType().getSimpleName();
+        Object value = ex.getValue();
+        String message = String.format("'%s' should be a valid '%s' and '%s' isn't", name, type, value);
+
+        ErrorResponse error = new ErrorResponse("BAD_REQUEST", message);
+        return new ResponseEntity<>(error, HttpStatus.BAD_REQUEST);
     }
 }

--- a/src/main/java/com/noblesse/backend/manage/clip/controller/ClipManagementController.java
+++ b/src/main/java/com/noblesse/backend/manage/clip/controller/ClipManagementController.java
@@ -1,0 +1,70 @@
+package com.noblesse.backend.manage.clip.controller;
+
+import com.noblesse.backend.manage.clip.dto.ReportedClipDTO;
+import com.noblesse.backend.manage.clip.dto.ReportedClipDetailDTO;
+import com.noblesse.backend.manage.clip.service.ClipManagementService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+@Slf4j
+@RestController
+@RequestMapping(value = "/admin/clip")
+@RequiredArgsConstructor
+@Tag(name = "클립 관리", description = "신고된 클립 관리 API")
+public class ClipManagementController {
+
+    private final ClipManagementService clipManagementService;
+
+    @Operation(summary = "신고된 클립 목록 조회")
+    @ApiResponse(responseCode = "200", description = "신고된 클립 목록 조회 성공")
+    @GetMapping("/reported")
+    // 신고 접수된 모든 회원 목록 조회 + 페이지네이션
+    public ResponseEntity<Page<ReportedClipDTO>> getAllReportedClips(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "5") int size,
+            @RequestParam(defaultValue = "clipReportedAt") String sortBy) {
+        return ResponseEntity.ok(clipManagementService.getAllReportedClips(page, size, sortBy));
+    }
+
+    @Operation(summary = "신고된 클립 상세 정보 조회")
+    @ApiResponse(responseCode = "200", description = "신고된 클립 상세 정보 조회 성공")
+    @GetMapping("/reported/{clipId}")
+    public ResponseEntity<ReportedClipDetailDTO> getReportedClipDetail(@PathVariable Long clipId) {
+        ReportedClipDetailDTO clipDetail = clipManagementService.getReportedClipDetail(clipId);
+        return ResponseEntity.ok(clipDetail);
+    }
+
+    @Operation(summary = "신고된 클립 삭제")
+    @ApiResponse(responseCode = "200", description = "신고된 클립 삭제 성공")
+    @DeleteMapping("/{clipId}")
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<?> deleteClipByAdmin(@PathVariable Long clipId) {
+        log.debug("Received delete request for clipId: {}", clipId);
+
+        if (clipId == null) {
+            log.warn("Attempt to delete clip with null ID");
+            return ResponseEntity.badRequest().body("Invalid clip ID: null");
+        }
+
+        try {
+            clipManagementService.deleteClipAndReports(clipId);
+            log.info("Successfully deleted clip with ID: {}", clipId);
+            return ResponseEntity.ok().build();
+        } catch (EntityNotFoundException e) {
+            log.warn("Attempt to delete non-existent clip with ID: {}", clipId);
+            return ResponseEntity.notFound().build();
+        } catch (Exception e) {
+            log.error("Error occurred while deleting clip with ID: {}", clipId, e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("Error deleting clip");
+        }
+    }
+}

--- a/src/main/java/com/noblesse/backend/manage/clip/dto/ReportedClipDTO.java
+++ b/src/main/java/com/noblesse/backend/manage/clip/dto/ReportedClipDTO.java
@@ -1,0 +1,20 @@
+package com.noblesse.backend.manage.clip.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class ReportedClipDTO {
+    private List<Long> clipIds;
+    private String email;
+    private List<String> clipTitles;
+    private List<String> clipUrls;
+    private LocalDateTime clipReportedAt;
+    private List<Long> reportedClips;
+}

--- a/src/main/java/com/noblesse/backend/manage/clip/dto/ReportedClipDetailDTO.java
+++ b/src/main/java/com/noblesse/backend/manage/clip/dto/ReportedClipDetailDTO.java
@@ -1,0 +1,19 @@
+package com.noblesse.backend.manage.clip.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class ReportedClipDetailDTO {
+    private Long clipId;
+    private String clipTitle;
+    private String email;
+    private String clipUrl;
+    private int reportCount;
+    private List<String> reportContents;
+}

--- a/src/main/java/com/noblesse/backend/manage/clip/service/ClipManagementService.java
+++ b/src/main/java/com/noblesse/backend/manage/clip/service/ClipManagementService.java
@@ -1,0 +1,149 @@
+package com.noblesse.backend.manage.clip.service;
+
+import com.noblesse.backend.clip.domain.Clip;
+import com.noblesse.backend.clip.domain.ClipReport;
+import com.noblesse.backend.clip.repository.ClipRepository;
+import com.noblesse.backend.clip.repository.ClipReportRepository;
+import com.noblesse.backend.file.service.FileService;
+import com.noblesse.backend.manage.clip.dto.ReportedClipDTO;
+import com.noblesse.backend.manage.clip.dto.ReportedClipDetailDTO;
+import com.noblesse.backend.oauth2.entity.OAuthUser;
+import com.noblesse.backend.oauth2.repository.OAuthRepository;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.*;
+import org.springframework.data.web.config.EnableSpringDataWebSupport;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+import static org.springframework.data.web.config.EnableSpringDataWebSupport.PageSerializationMode.VIA_DTO;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@EnableSpringDataWebSupport(pageSerializationMode = VIA_DTO)
+public class ClipManagementService {
+
+    private final ClipRepository clipRepository;
+    private final ClipReportRepository clipReportRepository;
+    private final OAuthRepository oAuthRepository;
+    private final FileService fileService;
+
+    public Page<ReportedClipDTO> getAllReportedClips(int page, int size, String sortBy) {
+        log.debug("Entering getAllReportedClips method");
+        Pageable pageable = PageRequest.of(page, size, Sort.by(sortBy));
+        Page<ClipReport> reportedClipPage = clipReportRepository.findAll(pageable);
+        log.debug("Found {} clip reports", reportedClipPage.getTotalElements());
+
+        Map<String, ReportedClipDTO> userClipsMap = new HashMap<>();
+
+        for (ClipReport report : reportedClipPage) {
+            log.debug("Processing report for clipId: {}", report.getClipId());
+            Clip clip = clipRepository.findById(report.getClipId())
+                    .orElseThrow(() -> new EntityNotFoundException("Clip not found for id: " + report.getClipId()));
+
+            OAuthUser user = oAuthRepository.findById(clip.getUserId())
+                    .orElseThrow(() -> new EntityNotFoundException("User not found for id: " + clip.getUserId()));
+
+            String email = user.getEmail();
+            String firebaseUrl = fileService.findImageDownloadLinkByFileUrl(clip.getClipUrl());
+            log.debug("Firebase URL for clip {}: {}", clip.getClipId(), firebaseUrl);
+
+            if (!userClipsMap.containsKey(email)) {
+                userClipsMap.put(email, new ReportedClipDTO(
+                        new ArrayList<>(),
+                        email,
+                        new ArrayList<>(),
+                        new ArrayList<>(),
+                        report.getClipReportedAt(),
+                        new ArrayList<>()
+                ));
+                log.debug("Created new DTO for email: {}", email);
+            }
+
+            ReportedClipDTO dto = userClipsMap.get(email);
+            dto.getClipIds().add(clip.getClipId());
+            dto.getClipTitles().add(clip.getClipTitle());
+            dto.getClipUrls().add(firebaseUrl);
+            dto.getReportedClips().add(clip.getClipId());
+            log.debug("Added clipId {} to reportedClips for email: {}", clip.getClipId(), email);
+
+            if (dto.getClipReportedAt().isBefore(report.getClipReportedAt())) {
+                dto.setClipReportedAt(report.getClipReportedAt());
+                log.debug("Updated clipReportedAt for email: {}", email);
+            }
+        }
+
+        List<ReportedClipDTO> resultList = new ArrayList<>(userClipsMap.values());
+        log.debug("Final result list size: {}", resultList.size());
+
+        // Sort the result list based on the sortBy parameter
+        if ("email".equals(sortBy)) {
+            resultList.sort(Comparator.comparing(ReportedClipDTO::getEmail));
+        } else {
+            resultList.sort(Comparator.comparing(ReportedClipDTO::getClipReportedAt).reversed());
+        }
+
+        int start = (int) pageable.getOffset();
+        int end = Math.min((start + pageable.getPageSize()), resultList.size());
+
+        Page<ReportedClipDTO> result = new PageImpl<>(resultList.subList(start, end), pageable, resultList.size());
+        log.debug("Returning page with {} elements", result.getContent().size());
+        return result;
+    }
+
+    public ReportedClipDetailDTO getReportedClipDetail(Long clipId) {
+        log.debug("### getReportedClipDetail 진입...");
+        log.debug("Get reported clip detail for clipId {}", clipId);
+        Clip clip = clipRepository.findClipByClipId(clipId);
+        if (clip == null) {
+            throw new EntityNotFoundException("Clip not found");
+        }
+
+        OAuthUser user = oAuthRepository.findById(clip.getUserId())
+                .orElseThrow(() -> new EntityNotFoundException("User not found"));
+        List<ClipReport> reports = clipReportRepository.findClipReportsByClip_ClipId(clipId);
+
+        String clipUrl = fileService.findImageDownloadLinkByFileUrl(clip.getClipUrl());
+        log.debug("clipUrl: {}", clipUrl);
+
+        return new ReportedClipDetailDTO(
+                clip.getClipId(),
+                clip.getClipTitle(),
+                user.getEmail(),
+                clipUrl,
+                reports.size(),
+                reports.stream().map(ClipReport::getClipReportContent).collect(Collectors.toList())
+        );
+    }
+
+    @Transactional
+    public void deleteClipAndReports(Long clipId) {
+        log.debug("Attempting to delete clip and reports for clipId: {}", clipId);
+
+        try {
+            Clip clip = clipRepository.findById(clipId)
+                    .orElseThrow(() -> new EntityNotFoundException("Clip not found with id: " + clipId));
+
+            log.debug("Found clip: {}", clip);
+
+            clipReportRepository.deleteByClip(clip);
+            log.debug("Deleted all reports for clipId: {}", clipId);
+
+            clipRepository.delete(clip);
+            log.debug("Deleted clip with id: {}", clipId);
+
+            // 파일 시스템에서 관련 파일 삭제 (만약 있다면)
+            fileService.deleteClipFileByClipId(clipId);
+            log.debug("Deleted associated files for clipId: {}", clipId);
+
+        } catch (Exception e) {
+            log.error("Error occurred while deleting clip and reports for clipId: {}", clipId, e);
+            throw e;
+        }
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -34,6 +34,10 @@ spring:
           secret: ${JWT_SECRET}
           access-expiration: 86400000
           refresh-expiration: 10800000
+  servlet:
+    multipart:
+      max-file-size: 100MB
+      max-request-size: 100MB
 server:
   port: 8443
   ssl:
@@ -48,3 +52,10 @@ app:
 google:
   maps:
     api-key: ${GOOGLE_MAPS_API_KEY}
+
+logging:
+  level:
+    com.noblesse.backend: debug
+    com.noblesse.backend.clip: debug
+    com.noblesse.backend.file: debug
+    com.noblesse.backend.manage.clip: debug

--- a/src/test/java/com/noblesse/backend/clip/ClipCRUDTests.java
+++ b/src/test/java/com/noblesse/backend/clip/ClipCRUDTests.java
@@ -25,8 +25,8 @@ public class ClipCRUDTests {
 
     private static Stream<Arguments> newClip() {
         return Stream.of(
-                Arguments.of(new ClipRegistRequestDTO("클립1", "클립URL주소1", true, 1L, 1L)),
-                Arguments.of(new ClipRegistRequestDTO("클립2", "클립URL주소2", true, 2L, 2L))
+                Arguments.of(new ClipRegistRequestDTO(null, "클립1", "클립URL주소1", true, 1L, 1L, null)),
+                Arguments.of(new ClipRegistRequestDTO(null, "클립2", "클립URL주소2", true, 2L, 2L, null))
         );
     }
 

--- a/src/test/java/com/noblesse/backend/manage/clip/ClipManagementTest.java
+++ b/src/test/java/com/noblesse/backend/manage/clip/ClipManagementTest.java
@@ -1,0 +1,179 @@
+package com.noblesse.backend.manage.clip;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.noblesse.backend.admin.dto.AdminLoginRequest;
+import com.noblesse.backend.clip.domain.Clip;
+import com.noblesse.backend.clip.domain.ClipReport;
+import com.noblesse.backend.clip.dto.ClipRegistRequestDTO;
+import com.noblesse.backend.clip.dto.ClipReportRegistRequestDTO;
+import com.noblesse.backend.clip.service.ClipReportService;
+import com.noblesse.backend.clip.service.ClipService;
+import com.noblesse.backend.oauth2.entity.OAuthUser;
+import com.noblesse.backend.oauth2.repository.OAuthRepository;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.util.List;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class ClipManagementTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private ClipService clipService;
+
+    @Autowired
+    private ClipReportService clipReportService;
+
+    @Autowired
+    private OAuthRepository oAuthRepository;
+
+    private static final String ADMIN_EMAIL = "admin@triplay.com";
+    private static final String ADMIN_PASSWORD = "admin";
+    private static final String TEST_USER_EMAIL = "testuser@example.com";
+
+    private String adminToken;
+    private Long testUserId;
+    private Long testClipId;
+
+    @BeforeAll
+    public void setup() throws Exception {
+        // 테스트 사용자 생성
+        OAuthUser testUser = new OAuthUser();
+        testUser.setEmail(TEST_USER_EMAIL);
+        testUser.setUserName("Test User");
+        testUser = oAuthRepository.save(testUser);
+        testUserId = testUser.getId();
+
+        MockMultipartFile mockFile = new MockMultipartFile(
+                "file",
+                "test.mp4",
+                "video/mp4",
+                "test video content".getBytes()
+        );
+
+        // 테스트 클립 생성
+        ClipRegistRequestDTO clipDTO = new ClipRegistRequestDTO();
+        clipDTO.setClipTitle("Test Clip");
+        clipDTO.setClipUrl("https://example.com/test-clip");
+        clipDTO.setIsOpened(true);
+        clipDTO.setUserId(testUserId);
+        clipDTO.setTripId(null); // 또는 적절한 tripId 설정
+        clipDTO.setFile(mockFile);
+
+        clipService.insertClip(clipDTO);
+        testClipId = clipService.findAll().get(0).getClipId(); // 방금 생성한 클립의 ID 가져오기
+
+        // 테스트 클립 신고 생성
+        ClipReportRegistRequestDTO reportDTO = new ClipReportRegistRequestDTO();
+        reportDTO.setReportCategoryId(1L);
+        reportDTO.setClipReportTitle("Test Report");
+        reportDTO.setClipReportContent("Test report content");
+        reportDTO.setUserId(testUserId);
+        reportDTO.setClipId(testClipId);
+        clipReportService.registClipReport(reportDTO);
+
+        // 관리자 로그인 및 토큰 획득
+        AdminLoginRequest adminLoginRequest = new AdminLoginRequest(ADMIN_EMAIL, ADMIN_PASSWORD);
+        MvcResult result = mockMvc.perform(post("/admin/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(adminLoginRequest)))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        String response = result.getResponse().getContentAsString();
+        adminToken = objectMapper.readTree(response).get("token").asText();
+    }
+
+    @AfterAll
+    public void cleanup() {
+        List<ClipReport> reports = clipReportService.findAll();
+        if (!reports.isEmpty()) {
+            clipReportService.deleteClipReportByClipReportId(reports.get(0).getClipReportId());
+        }
+
+        List<Clip> clips = clipService.findAll();
+        if (!clips.isEmpty()) {
+            clipService.deleteClipByClipId(clips.get(0).getClipId());
+        }
+
+        if (testUserId != null) {
+            oAuthRepository.deleteById(testUserId);
+        }
+    }
+
+    @DisplayName("#01. 신고된 클립 목록 조회 테스트")
+    @Test
+    @Order(1)
+    public void testGetReportedClips() throws Exception {
+        mockMvc.perform(get("/admin/clip/reported")
+                        .header("Authorization", "Bearer " + adminToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content").isArray())
+                .andExpect(jsonPath("$.content[0].clipIds[0]").value(testClipId))
+                .andExpect(jsonPath("$.content[0].email").value(TEST_USER_EMAIL));
+    }
+
+    @DisplayName("#02. 신고된 클립 상세 정보 조회 테스트")
+    @Test
+    @Order(2)
+    public void testGetReportedClipDetail() throws Exception {
+        mockMvc.perform(get("/admin/clip/reported/" + testClipId)
+                        .header("Authorization", "Bearer " + adminToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.clipId").value(testClipId))
+                .andExpect(jsonPath("$.clipTitle").value("Test Clip"))
+                .andExpect(jsonPath("$.email").value(TEST_USER_EMAIL));
+    }
+
+    @DisplayName("#03. 클립 삭제 테스트")
+    @Test
+    @Order(3)
+    public void testDeleteClip() throws Exception {
+        mockMvc.perform(delete("/admin/clip/" + testClipId)
+                        .header("Authorization", "Bearer " + adminToken))
+                .andExpect(status().isOk());
+
+        // 클립이 실제로 삭제되었는지 확인
+        mockMvc.perform(get("/admin/clip/reported/" + testClipId)
+                        .header("Authorization", "Bearer " + adminToken))
+                .andExpect(status().isNotFound());
+    }
+
+    @DisplayName("#04. 인증 없이 클립 관리 API 접근 테스트")
+    @Test
+    @Order(4)
+    public void testUnauthorizedAccess() throws Exception {
+        mockMvc.perform(get("/admin/clip/reported"))
+                .andExpect(status().isUnauthorized());
+
+        mockMvc.perform(delete("/admin/clip/" + testClipId))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @DisplayName("#05. 존재하지 않는 클립 삭제 시도 테스트")
+    @Test
+    @Order(5)
+    public void testDeleteNonExistentClip() throws Exception {
+        mockMvc.perform(delete("/admin/clip/99999")
+                        .header("Authorization", "Bearer " + adminToken))
+                .andExpect(status().isNotFound());
+    }
+}


### PR DESCRIPTION
## ⭐Key Changes
> 핵심 변경 사항에 대해서 적어주세요.
1. 기존 ‘클립’ 관련 도메인과의 충돌을 피하기 위해 별도의 ‘클립 관리’ 도메인을 작성
2. “클립 추가” 엔드포인트 호출 시, file 테이블의 ‘file_type', ‘file_name’, ‘file_url’에 각각 clip, fileName, clip/{clipId}/{fileNameWithExtension} 와 같이 삽입되도록 로직 수정
3. 테스트 코드 작성 완료

<br>

## 📌Issue
> 닫을 issue 번호 : resolved #71

<br>

## 🩼Branch
> 반영 branch feat-71 -> dev

<br>

## 👪To Reviewers
> 맞게 작성한 것인지, 자신이 없어용... 기능 단위로 구현을 했어야 했는데..